### PR TITLE
Test hypothesis

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,9 +79,10 @@ runs:
         with:
           path: /usr/lib/postgresql
           key: ${{ runner.os }}-postgresql-client
+
       # Install step: installs PostgreSQL only if it's not found in the cache
       - name: Install PostgreSQL Client
-        if: steps.cache-psql.outputs.cache-hit != 'true' || !command -v psql
+        if: steps.cache-psql.outputs.cache-hit != 'true' 
         run: |
           sudo apt-get update -qq
           sudo apt-get install --yes --no-install-recommends postgresql-client

--- a/action.yml
+++ b/action.yml
@@ -72,9 +72,16 @@ runs:
           app_db: "${{ inputs.db_name }}"
           postgres_extensions: "${{ inputs.db_extensions }}"
 
-
+      # Cache step: tries to restore the PostgreSQL client from cache
+      - name: Cache PostgreSQL Client
+        id: cache-psql
+        uses: actions/cache@v3
+        with:
+          path: /usr/lib/postgresql
+          key: ${{ runner.os }}-postgresql-client
       # Install step: installs PostgreSQL only if it's not found in the cache
-      - name: Install psql
+      - name: Install PostgreSQL Client
+        if: steps.cache-psql.outputs.cache-hit != 'true' || !command -v psql
         run: |
           sudo apt-get update -qq
           sudo apt-get install --yes --no-install-recommends postgresql-client

--- a/action.yml
+++ b/action.yml
@@ -72,19 +72,9 @@ runs:
           app_db: "${{ inputs.db_name }}"
           postgres_extensions: "${{ inputs.db_extensions }}"
 
-      # Cache step: tries to restore the PostgreSQL client from cache
-      - name: Cache PostgreSQL Client
-        id: cache-psql
-        uses: actions/cache@v3
-        with:
-          path: /usr/bin/psql
-          key: ${{ runner.os }}-postgresql-client
-          restore-keys: |
-            ${{ runner.os }}-postgresql-client
 
       # Install step: installs PostgreSQL only if it's not found in the cache
       - name: Install psql
-        if: steps.cache-psql.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install --yes --no-install-recommends postgresql-client


### PR DESCRIPTION
## Description
- hypothesis: we are never using the postgres sql client cache

When restoring it it fails (it thinks it is because of a file system problem):
 
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/6851316b-627e-4778-a812-a24610843ae1" />

So it is never used. But it is saved on each cache miss, this usually takes 2 mins, and happens on each pr creation.

Other problem of this solution is that the cache is created in a branch scope so it can only be accesed on the branch. For it to be accesible for all the branches it should be created on main.

So this pr is to test if this is correct.
