### PR TITLE
Change Postgres action to fkmurphy version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
  
   steps:
       - name: Setup Postgres database
-        uses: fkmurphy/postgresql-action@master
+        uses: Daniel-Marynicz/postgresql-action@fcac9ac7d2db5031132953bc7cfe88f77a65badc
         with:
           postgres_image_tag: 0.7.0-pg12
           postgres_image_name: pgvector/pgvector

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
  
   steps:
       - name: Setup Postgres database
-        uses: Daniel-Marynicz/postgresql-action@master
+        uses: fkmurphy/postgresql-action@master
         with:
           postgres_image_tag: 0.7.0-pg12
           postgres_image_name: pgvector/pgvector


### PR DESCRIPTION
Usar version 29 de docker in docker
https://github.com/fkmurphy/postgresql-action

Abri pr igualmente en el repo que usamos
https://github.com/Daniel-Marynicz/postgresql-action/pull/5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Edit:
se mergeó la versión :29, pongo fixed el hash, sabemos que funciona.