### PR TITLE
fix(security): prevent template injection in remaining migration steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,12 +134,19 @@ runs:
         shell: bash
         id: make-migrations-before-clerk
         if: inputs.migrate_self == 'true' && inputs.migrate_self_before == 'clerk'
+        env:
+          DB_PORT: ${{ inputs.db_port }}
+          DB_NAME: ${{ inputs.db_name }}
+          DB_USER: ${{ inputs.db_user }}
+          DB_PASSWORD: ${{ inputs.db_password }}
+          DB_MIGRATIONS_PATH: ${{ inputs.db_migrations_path }}
+          DB_MIGRATIONS_CONFIG_PATH: ${{ inputs.db_migrations_config_path }}
         run: |
-          flyway migrate -url=jdbc:postgresql://localhost:${{ inputs.db_port }}/${{ inputs.db_name }} \
-            -user=${{ inputs.db_user }} \
-            -password=${{ inputs.db_password }} \
-            -locations=${{ inputs.db_migrations_path }} \
-            -configFiles=${{ inputs.db_migrations_config_path }}
+          flyway migrate -url=jdbc:postgresql://localhost:$DB_PORT/$DB_NAME \
+            -user=$DB_USER \
+            -password=$DB_PASSWORD \
+            -locations=$DB_MIGRATIONS_PATH \
+            -configFiles=$DB_MIGRATIONS_CONFIG_PATH
 
       # Migrate clerk service
       - name: Copy migrations from clerk-service
@@ -170,12 +177,19 @@ runs:
         shell: bash
         id: make-migrations-before-chat
         if: inputs.migrate_self == 'true' && inputs.migrate_self_before == 'chat'
+        env:
+          DB_PORT: ${{ inputs.db_port }}
+          DB_NAME: ${{ inputs.db_name }}
+          DB_USER: ${{ inputs.db_user }}
+          DB_PASSWORD: ${{ inputs.db_password }}
+          DB_MIGRATIONS_PATH: ${{ inputs.db_migrations_path }}
+          DB_MIGRATIONS_CONFIG_PATH: ${{ inputs.db_migrations_config_path }}
         run: |
-          flyway migrate -url=jdbc:postgresql://localhost:${{ inputs.db_port }}/${{ inputs.db_name }} \
-            -user=${{ inputs.db_user }} \
-            -password=${{ inputs.db_password }} \
-            -locations=${{ inputs.db_migrations_path }} \
-            -configFiles=${{ inputs.db_migrations_config_path }}
+          flyway migrate -url=jdbc:postgresql://localhost:$DB_PORT/$DB_NAME \
+            -user=$DB_USER \
+            -password=$DB_PASSWORD \
+            -locations=$DB_MIGRATIONS_PATH \
+            -configFiles=$DB_MIGRATIONS_CONFIG_PATH
             
       # Migrate chat service
       - name: Copy migrations from chat
@@ -206,12 +220,19 @@ runs:
         shell: bash
         id: make-migrations-before-employee
         if: inputs.migrate_self == 'true' && inputs.migrate_self_before == 'employee'
+        env:
+          DB_PORT: ${{ inputs.db_port }}
+          DB_NAME: ${{ inputs.db_name }}
+          DB_USER: ${{ inputs.db_user }}
+          DB_PASSWORD: ${{ inputs.db_password }}
+          DB_MIGRATIONS_PATH: ${{ inputs.db_migrations_path }}
+          DB_MIGRATIONS_CONFIG_PATH: ${{ inputs.db_migrations_config_path }}
         run: |
-          flyway migrate -url=jdbc:postgresql://localhost:${{ inputs.db_port }}/${{ inputs.db_name }} \
-            -user=${{ inputs.db_user }} \
-            -password=${{ inputs.db_password }} \
-            -locations=${{ inputs.db_migrations_path }} \
-            -configFiles=${{ inputs.db_migrations_config_path }}
+          flyway migrate -url=jdbc:postgresql://localhost:$DB_PORT/$DB_NAME \
+            -user=$DB_USER \
+            -password=$DB_PASSWORD \
+            -locations=$DB_MIGRATIONS_PATH \
+            -configFiles=$DB_MIGRATIONS_CONFIG_PATH
 
       # Migrate employee service
       - name: Copy migrations from employee-service


### PR DESCRIPTION
## Summary
- Fixes template injection vulnerability in 3 migration steps (clerk, chat, employee) that were using `${{ inputs.* }}` directly in `run:` shell blocks
- Moves input values to `env:` block and references them as shell variables (`$DB_PORT`, `$DB_USER`, etc.), consistent with the pattern already used in other steps

## Test plan
- [x] Verify CI pipelines that use `migrate_self_before: clerk`, `chat`, or `employee` still work correctly
- [x] Confirm no `${{ inputs.* }}` expressions remain inside `run:` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated database migration configuration to use environment variables for parameter passing across multiple CI/CD workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->