### PR TITLE
chore: migrate postgresql-action to meetlara fork and bump pgvector to pg16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,9 +81,9 @@ runs:
  
   steps:
       - name: Setup Postgres database
-        uses: Daniel-Marynicz/postgresql-action@fcac9ac7d2db5031132953bc7cfe88f77a65badc
+        uses: meetlara/postgresql-action@2.0.0
         with:
-          postgres_image_tag: 0.7.0-pg12
+          postgres_image_tag: 0.8.2-pg16
           postgres_image_name: pgvector/pgvector
           app_user: "${{ inputs.db_user }}"
           app_user_password: "${{ inputs.db_password }}"


### PR DESCRIPTION
## Summary
- Migrated `Daniel-Marynicz/postgresql-action` (pinned to commit `fcac9ac`) to `meetlara/postgresql-action@2.0.0` (latest tag in the fork).
- Bumped `postgres_image_tag` from `0.7.0-pg12` to `0.8.2-pg16` to align with the postgres 16 version used across services.

## Test plan
- [ ] Verify CI runs the action successfully and the postgres container starts on pg16
- [ ] Spot-check downstream consumers' migrations still apply on pg16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL database version from PostgreSQL 12 to PostgreSQL 16 in the CI/CD pipeline
  * Updated PostgreSQL tooling dependencies to compatible versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->